### PR TITLE
Migrate CI to GitHub Actions - closes #6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        node: [ '12', '10', '8' ]
+    name: Node ${{ matrix.node }} (${{ matrix.platform }})
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: install dependencies
+        run: yarn
+      - name: run tests
+        run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - '12'
-  - '10'
-  - '8'
-notifications:
-  email:
-    on_success: never

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # png-to-ico
 
-[![Build Status](https://travis-ci.org/steambap/png-to-ico.svg?branch=master)](https://travis-ci.org/steambap/png-to-ico)
+[![Build Status](https://github.com/steambap/png-to-ico/workflows/CI/badge.svg)](https://github.com/steambap/png-to-ico/actions?workflow=CI)
 
 > convert png to windows ico format
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,6 @@
 # png-to-ico
 
-[![Build Status](https://travis-ci.org/steambap/png-to-ico.svg?branch=master)](https://travis-ci.org/steambap/png-to-ico)
+[![Build Status](https://github.com/steambap/png-to-ico/workflows/CI/badge.svg)](https://github.com/steambap/png-to-ico/actions?workflow=CI)
 
 > png 转 ico 格式
 


### PR DESCRIPTION
This PR migrates the CI setup to GitHub Actions.

Regarding notifications, see https://help.github.com/en/articles/choosing-the-delivery-method-for-your-notifications#choosing-the-delivery-method-for-notifications-about-github-actions